### PR TITLE
feat: properties macro uses expr instead of literal for values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markupsth"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Michael Eberhardt <github@michael-eberhardt.de>"]
 edition = "2021"
 description = "Crate to define and print out formatted Markup Languages."

--- a/src/markupsth.rs
+++ b/src/markupsth.rs
@@ -284,7 +284,7 @@ impl<'d> MarkupSth<'d> {
 /// Simplifies using `MarkupSth::properties()` and calls this method internally.
 #[macro_export]
 macro_rules! properties {
-    ($markup:expr, $($name:literal, $value:literal),*) => {{
+    ($markup:expr, $($name:literal, $value:expr),*) => {{
         $markup.properties(&[$(($name, $value)),*])
     }};
 }


### PR DESCRIPTION
Change macro `properties` parameter `$value` from type `literal` to `expr`