### PR TITLE
feat: rename rule-set and improve inner logic

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+max_width = 100
+wrap_comments = true
+comment_width = 100
+format_strings = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 //! you need to implement:
 //! ```
 //! use markupsth::{
-//!     AutoIndent, FixedRule, Language, MarkupSth, properties,
+//!     AutoIndent, AutoFmtRule, Language, MarkupSth, properties,
 //! };
 //!
 //! // Setup a document (String), MarkupSth and a default formatter.
@@ -54,11 +54,11 @@
 //! let mut mus = MarkupSth::new(&mut document, Language::Html).unwrap();
 //
 //! // Default Formatter is an AutoIndent, so get it, configure it!
-//! let fmtr = mus.formatter.optional_fixed_ruleset().unwrap();
-//! fmtr.add_tags_to_rule(&["head", "body", "section"], FixedRule::IndentAlways)
+//! let fmtr = mus.formatter.get_ext_auto_indenting().unwrap();
+//! fmtr.add_tags_to_rule(&["head", "body", "section"], AutoFmtRule::IndentAlways)
 //!     .unwrap();
-//! fmtr.add_tags_to_rule(&["html"], FixedRule::LfAlways).unwrap();
-//! fmtr.add_tags_to_rule(&["title", "link", "div", "p"], FixedRule::LfClosing)
+//! fmtr.add_tags_to_rule(&["html"], AutoFmtRule::LfAlways).unwrap();
+//! fmtr.add_tags_to_rule(&["title", "link", "div", "p"], AutoFmtRule::LfClosing)
 //!     .unwrap();
 //!
 //! // Generate the content of example shown above.
@@ -81,7 +81,7 @@
 //! mus.finalize().unwrap();
 //! # assert_eq!(document, markupsth::testfile("formatted_html_auto_indent.html"));
 //! ```
-//!
+//! 
 //! ### Readable XML
 //!
 //! To generate the following output:
@@ -101,7 +101,7 @@
 //! ```
 //! you have to implement:
 //! ```
-//! use markupsth::{AutoIndent, FixedRule, Language, MarkupSth, properties};
+//! use markupsth::{AutoIndent, AutoFmtRule, Language, MarkupSth, properties};
 //!
 //! let do_entry = |mus: &mut MarkupSth, name: &str| {
 //!     mus.open("entry").unwrap();
@@ -120,9 +120,9 @@
 //! let mut mus = MarkupSth::new(&mut document, Language::Html).unwrap();
 //!
 //! // Default Formatter is an AutoIndent, so get it, configure it!
-//! let fmtr = mus.formatter.optional_fixed_ruleset().unwrap();
-//! fmtr.add_tags_to_rule(&["directory", "entry"], FixedRule::IndentAlways).unwrap();
-//! fmtr.add_tags_to_rule(&["title", "keyword", "entrystext"], FixedRule::LfClosing).unwrap();
+//! let fmtr = mus.formatter.get_ext_auto_indenting().unwrap();
+//! fmtr.add_tags_to_rule(&["directory", "entry"], AutoFmtRule::IndentAlways).unwrap();
+//! fmtr.add_tags_to_rule(&["title", "keyword", "entrystext"], AutoFmtRule::LfClosing).unwrap();
 //!
 //! // Generate the content of example shown above.
 //! mus.open("directory").unwrap();
@@ -141,7 +141,7 @@ pub mod markupsth;
 pub mod syntax;
 
 pub use crate::{
-    format::{FixedRule, FixedRuleset, Formatter},
+    format::{AutoFmtRule, ExtAutoIndenting, Formatter},
     formatters::*,
     markupsth::MarkupSth,
     syntax::Language,
@@ -209,6 +209,7 @@ mod tests {
         let mut mus = MarkupSth::new(&mut document, Language::Html).unwrap();
 
         mus.set_formatter(Box::new(AlwaysIndentAlwaysLf::new()));
+
         mus.open("head").unwrap();
         mus.self_closing("meta").unwrap();
         properties!(mus, "charset", "utf-8").unwrap();
@@ -230,12 +231,12 @@ mod tests {
         let mut mus = MarkupSth::new(&mut document, Language::Html).unwrap();
 
         // Default Formatter is an AutoIndent, so get it, configure it!
-        let fmtr = mus.formatter.optional_fixed_ruleset().unwrap();
-        fmtr.add_tags_to_rule(&["head", "body", "section"], FixedRule::IndentAlways)
+        let fmtr = mus.formatter.get_ext_auto_indenting().unwrap();
+        fmtr.add_tags_to_rule(&["head", "body", "section"], AutoFmtRule::IndentAlways)
             .unwrap();
-        fmtr.add_tags_to_rule(&["html"], FixedRule::LfAlways)
+        fmtr.add_tags_to_rule(&["html"], AutoFmtRule::LfAlways)
             .unwrap();
-        fmtr.add_tags_to_rule(&["title", "link", "div", "p"], FixedRule::LfClosing)
+        fmtr.add_tags_to_rule(&["title", "link", "div", "p"], AutoFmtRule::LfClosing)
             .unwrap();
 
         mus.open("html").unwrap();
@@ -276,10 +277,10 @@ mod tests {
         let mut document = String::new();
         let mut mus = MarkupSth::new(&mut document, Language::Xml).unwrap();
         // Default Formatter is an AutoIndent, so get it, configure it!
-        let fmtr = mus.formatter.optional_fixed_ruleset().unwrap();
-        fmtr.add_tags_to_rule(&["directory", "entry"], FixedRule::IndentAlways)
+        let fmtr = mus.formatter.get_ext_auto_indenting().unwrap();
+        fmtr.add_tags_to_rule(&["directory", "entry"], AutoFmtRule::IndentAlways)
             .unwrap();
-        fmtr.add_tags_to_rule(&["title", "keyword", "entrystext"], FixedRule::LfClosing)
+        fmtr.add_tags_to_rule(&["title", "keyword", "entrystext"], AutoFmtRule::LfClosing)
             .unwrap();
 
         mus.open("directory").unwrap();

--- a/src/markupsth.rs
+++ b/src/markupsth.rs
@@ -87,7 +87,7 @@ macro_rules! final_op_arm {
 pub(crate) use final_op_arm;
 
 impl<'d> MarkupSth<'d> {
-    /// New type pattern for creating a new MarkupSth.
+    /// New type pattern for creating a new MarkupSth instance.
     pub fn new(document: &'d mut String, ml: Language) -> Result<MarkupSth<'d>> {
         Ok(MarkupSth {
             syntax: SyntaxConfig::from(ml),
@@ -203,7 +203,15 @@ impl<'d> MarkupSth<'d> {
 
     pub fn new_line(&mut self) -> Result<()> {
         self.finalize_last_op(TagSequence::linefeed())?;
-        // self.seq_state.last.0 = Sequence::LineFeed;
+        self.new_line_internal()?;
+        Ok(())
+    }
+
+    pub fn new_lines(&mut self, n: usize) -> Result<()> {
+        self.new_line()?;
+        for _ in 1..n {
+            self.new_line_internal()?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
- added new method `new_lines`
- marked auto-indenting explicitly as an extension
- improved inner logic about line feeds